### PR TITLE
Bed pxu

### DIFF
--- a/ConfigSamples/JuicyBoard/config.cnc
+++ b/ConfigSamples/JuicyBoard/config.cnc
@@ -54,6 +54,13 @@ stepmotor_4_current                          1000
 stepmotor_4_decay_mode                       fast
 gamma_max_rate                               5000.0           # mm/min
 
+# RS485 modbus config
+modbus.slot                                  2
+modbus.baud                                  9600
+modbus.databits                              8
+modbus.stopbits                              1
+modbus.parity                                N
+
 ## System configuration
 # Serial communications configuration ( baud rate defaults to 9600 if undefined )
 uart0.baud_rate                              115200           # Baud rate for the default hardware serial port

--- a/Juicyware.code-workspace
+++ b/Juicyware.code-workspace
@@ -3,5 +3,10 @@
 		{
 			"path": "."
 		}
-	]
+	],
+	"settings": {
+		"files.associations": {
+			"istream": "cpp"
+		}
+	}
 }

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -35,7 +35,8 @@
 #endif
 
 // Juicyboard specific
-#include "modules/JuicyBoard/R1000A_I2C/R1000A_I2C.h"
+//#include "modules/JuicyBoard/R1000A_I2C/R1000A_I2C.h"
+//#include "modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.h"
 
 #include "platform_memory.h"
 
@@ -85,10 +86,6 @@ Kernel::Kernel()
 
     this->current_path   = "/";
 
-    // Juicyware
-    // add Juicyboard I2C as part of kernel to save memory
-    this->i2c = new R1000A_I2C();
-
     // Configure UART depending on MRI config
     // Match up the SerialConsole to MRI UART. This makes it easy to use only one UART for both debug and actual commands.
     NVIC_SetPriorityGrouping(0);
@@ -116,6 +113,11 @@ Kernel::Kernel()
     if(this->serial == NULL) {
         this->serial = new(AHB0) SerialConsole(USBTX, USBRX, this->config->value(uart0_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
     }
+
+    // Juicyware
+    // add Juicyboard I2C as part of kernel to save memory
+    this->i2c = new R1000A_I2C();
+    this->modbus = new R1000A_MODBUS();
 
     //some boards don't have leds.. TOO BAD!
     this->use_leds = !this->config->value( disable_leds_checksum )->by_default(false)->as_bool();

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -37,6 +37,7 @@
 // Juicyboard specific
 //#include "modules/JuicyBoard/R1000A_I2C/R1000A_I2C.h"
 //#include "modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.h"
+#include "Pin.h"
 
 #include "platform_memory.h"
 
@@ -55,6 +56,13 @@
 #define grbl_mode_checksum                          CHECKSUM("grbl_mode")
 #define feed_hold_enable_checksum                   CHECKSUM("enable_feed_hold")
 #define ok_per_line_checksum                        CHECKSUM("ok_per_line")
+
+#define modbus_checksum             CHECKSUM("modbus")
+#define slotnum_checksum            CHECKSUM("slot")
+#define baud_checksum               CHECKSUM("baud")
+#define databits_checksum           CHECKSUM("databits")
+#define stopbits_checksum           CHECKSUM("stopbits")
+#define parity_checksum             CHECKSUM("parity")
 
 Kernel* Kernel::instance;
 
@@ -117,7 +125,12 @@ Kernel::Kernel()
     // Juicyware
     // add Juicyboard I2C as part of kernel to save memory
     this->i2c = new R1000A_I2C();
-    this->modbus = new R1000A_MODBUS();
+    this->modbus = new R1000A_MODBUS(   this->config->value(modbus_checksum, slotnum_checksum)->by_default(0)->as_int() ,
+                                        this->config->value(modbus_checksum, baud_checksum)->by_default(9600)->as_int() ,
+                                        this->config->value(modbus_checksum, databits_checksum)->by_default(8)->as_int() ,
+                                        this->config->value(modbus_checksum, stopbits_checksum)->by_default(1)->as_int() ,
+                                        this->config->value(modbus_checksum, parity_checksum)->by_default("N")->as_string()
+                                            );
 
     //some boards don't have leds.. TOO BAD!
     this->use_leds = !this->config->value( disable_leds_checksum )->by_default(false)->as_bool();

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -19,6 +19,7 @@
 
 // Juicyboard specific
 #include "modules/JuicyBoard/R1000A_I2C/R1000A_I2C.h"
+#include "modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.h"
 
 //Module manager
 class Config;
@@ -75,6 +76,7 @@ class Kernel {
 
         // adding I2C for Juicyboard
         R1000A_I2C*       i2c;
+        R1000A_MODBUS*    modbus;
 
         SlowTicker*       slow_ticker;
         StepTicker*       step_ticker;

--- a/src/modules/JuicyBoard/PXUsensor/PXUsensor.cpp
+++ b/src/modules/JuicyBoard/PXUsensor/PXUsensor.cpp
@@ -18,7 +18,8 @@
 PXUsensor::PXUsensor(){
     // Default Constructor
     // do nothing
-    current_temp = -1;       // initial value
+    current_temp = -1;      // initial value
+    
 }
 
 PXUsensor::~PXUsensor(){
@@ -27,6 +28,7 @@ PXUsensor::~PXUsensor(){
 void PXUsensor::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum){
     // load slot and channel numbers from config file
     modbus_addr = THEKERNEL->config->value(module_checksum, name_checksum, maddr_checksum)->by_default(1)->as_int();
+    set_temperature(0);     // turn off heater on module load
 }
 
 float PXUsensor::get_temperature(){

--- a/src/modules/JuicyBoard/PXUsensor/PXUsensor.cpp
+++ b/src/modules/JuicyBoard/PXUsensor/PXUsensor.cpp
@@ -1,0 +1,50 @@
+/*
+ * PXUsensor.cpp
+ *
+ *  Created on: May 13, 2020
+ *      Author: Sherif Eid
+ */
+
+#include "PXUsensor.h"
+#include "libs/Kernel.h"
+#include "Config.h"
+#include "checksumm.h"
+#include "ConfigValue.h"
+
+#define maddr_checksum CHECKSUM("maddr")
+#define REG_PV  0           // address for process value readout
+#define REG_SP  1           // address for setpoint
+
+PXUsensor::PXUsensor(){
+    // Default Constructor
+    // do nothing
+    current_temp = -1;       // initial value
+}
+
+PXUsensor::~PXUsensor(){
+}
+
+void PXUsensor::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum){
+    // load slot and channel numbers from config file
+    modbus_addr = THEKERNEL->config->value(module_checksum, name_checksum, maddr_checksum)->by_default(1)->as_int();
+}
+
+float PXUsensor::get_temperature(){
+    // returns set temperature
+    return current_temp;
+}
+
+void PXUsensor::pull_temperature(){
+    // returns set temperature
+    int val = THEKERNEL->modbus->read_holding_register(modbus_addr, REG_PV);
+    current_temp = (float)val/10.0;
+}
+
+void PXUsensor::set_temperature(float tempval){
+    // sets temperature
+    int tempint = ceil((int)(tempval * 10));
+    THEKERNEL->modbus->write_holding_register(modbus_addr, REG_SP, tempint);
+    // also reads current temperature
+    int val = THEKERNEL->modbus->read_holding_register(modbus_addr, REG_PV);
+    current_temp = (float)val/10.0;
+}

--- a/src/modules/JuicyBoard/PXUsensor/PXUsensor.cpp
+++ b/src/modules/JuicyBoard/PXUsensor/PXUsensor.cpp
@@ -15,6 +15,8 @@
 #define REG_PV  0           // address for process value readout
 #define REG_SP  1           // address for setpoint
 
+#define PXU_DELAY    150     // delay in ms between request and read response
+
 PXUsensor::PXUsensor(){
     // Default Constructor
     // do nothing
@@ -38,7 +40,7 @@ float PXUsensor::get_temperature(){
 
 void PXUsensor::pull_temperature(){
     // returns set temperature
-    int val = THEKERNEL->modbus->read_holding_register(modbus_addr, REG_PV);
+    int val = THEKERNEL->modbus->read_holding_register(modbus_addr, REG_PV, PXU_DELAY);
     current_temp = (float)val/10.0;
 }
 
@@ -46,7 +48,7 @@ void PXUsensor::set_temperature(float tempval){
     // sets temperature
     int tempint = ceil((int)(tempval * 10));
     THEKERNEL->modbus->write_holding_register(modbus_addr, REG_SP, tempint);
-    // also reads current temperature
-    int val = THEKERNEL->modbus->read_holding_register(modbus_addr, REG_PV);
-    current_temp = (float)val/10.0;
+    // also reads current temperature ( 2 times, give PXU some delay to execute and update temperature)
+    pull_temperature();
+    pull_temperature();
 }

--- a/src/modules/JuicyBoard/PXUsensor/PXUsensor.h
+++ b/src/modules/JuicyBoard/PXUsensor/PXUsensor.h
@@ -1,0 +1,30 @@
+/*
+ * PXUsensor.h
+ *
+ *  Created on: May 13, 2020
+ *      Author: Sherif Eid
+ */
+
+#ifndef SRC_MODULES_JUICYBOARD_PXUSENSOR_PXUSENSOR_H_
+#define SRC_MODULES_JUICYBOARD_PXUSENSOR_PXUSENSOR_H_
+
+#include "TempSensor.h"
+
+class PXUsensor : public TempSensor{
+    public:
+        // Default Constructor
+        PXUsensor();
+        ~PXUsensor();
+
+        void UpdateConfig(uint16_t module_checksum, uint16_t name_checksum);            // reads config file
+        float get_temperature();                                                        // returns current_temp
+        void set_temperature(float tempval);                                            // temperature value to set
+        void pull_temperature();                                                        // forces temperature to be read from PXU
+
+    private:
+        float current_temp;
+        int modbus_addr;
+};
+
+
+#endif /* SRC_MODULES_JUICYBOARD_PXUSENSOR_PXUSENSOR_H_ */

--- a/src/modules/JuicyBoard/R1000A/R1000A.cpp
+++ b/src/modules/JuicyBoard/R1000A/R1000A.cpp
@@ -348,16 +348,18 @@ void R1000A::on_console_line_received(void* argument){
             THEKERNEL->streams->printf("Sending test string to modbus\r\n");
             THEKERNEL->modbus->send_test_string();
         }
-        else if (cmd == "setbed"){
+        else if (cmd == "writemodbus"){
+            int slaveaddr = (int)strtol(shift_parameter(possible_command).c_str(), NULL, 10); 
             int regaddr =  (int)strtol(shift_parameter(possible_command).c_str(), NULL, 10);
             int tempval =  (int)strtol(shift_parameter(possible_command).c_str(), NULL, 10);
 
-            THEKERNEL->modbus->write_holding_register(1, regaddr, tempval);
+            THEKERNEL->modbus->write_holding_register(slaveaddr, regaddr, tempval);
             THEKERNEL->streams->printf("Setting bed modbus bed reg %d to %d\r\n", regaddr, tempval);
         }
-        else if (cmd == "readbed"){
+        else if (cmd == "readmodbus"){
+            int slaveaddr = (int)strtol(shift_parameter(possible_command).c_str(), NULL, 10);
             int regaddr =  (int)strtol(shift_parameter(possible_command).c_str(), NULL, 10);
-            int val = THEKERNEL->modbus->read_holding_register(1, regaddr);
+            int val = THEKERNEL->modbus->read_holding_register(slaveaddr, regaddr);
             THEKERNEL->streams->printf("modbus bed reg %d reads %d\r\n", regaddr, val);
         }
     }

--- a/src/modules/JuicyBoard/R1000A/R1000A.cpp
+++ b/src/modules/JuicyBoard/R1000A/R1000A.cpp
@@ -344,6 +344,10 @@ void R1000A::on_console_line_received(void* argument){
 
             THEKERNEL->i2c->enablemodI2C();
         }
+        else if (cmd == "testmodbus"){
+            THEKERNEL->streams->printf("Sending test string to modbus\r\n");
+            THEKERNEL->modbus->send_test_string();
+        }
     }
 }
 

--- a/src/modules/JuicyBoard/R1000A/R1000A.cpp
+++ b/src/modules/JuicyBoard/R1000A/R1000A.cpp
@@ -359,7 +359,7 @@ void R1000A::on_console_line_received(void* argument){
         else if (cmd == "readmodbus"){
             int slaveaddr = (int)strtol(shift_parameter(possible_command).c_str(), NULL, 10);
             int regaddr =  (int)strtol(shift_parameter(possible_command).c_str(), NULL, 10);
-            int val = THEKERNEL->modbus->read_holding_register(slaveaddr, regaddr);
+            int val = THEKERNEL->modbus->read_holding_register(slaveaddr, regaddr, 500);
             THEKERNEL->streams->printf("modbus bed reg %d reads %d\r\n", regaddr, val);
         }
     }

--- a/src/modules/JuicyBoard/R1000A/R1000A.cpp
+++ b/src/modules/JuicyBoard/R1000A/R1000A.cpp
@@ -348,6 +348,12 @@ void R1000A::on_console_line_received(void* argument){
             THEKERNEL->streams->printf("Sending test string to modbus\r\n");
             THEKERNEL->modbus->send_test_string();
         }
+        else if (cmd == "setbed"){
+            int regaddr =  (int)strtol(shift_parameter(possible_command).c_str(), NULL, 10);
+            int tempval =  (int)strtol(shift_parameter(possible_command).c_str(), NULL, 10);
+
+            THEKERNEL->modbus->write_holding_register(19, regaddr, tempval);
+        }
     }
 }
 

--- a/src/modules/JuicyBoard/R1000A/R1000A.cpp
+++ b/src/modules/JuicyBoard/R1000A/R1000A.cpp
@@ -352,7 +352,13 @@ void R1000A::on_console_line_received(void* argument){
             int regaddr =  (int)strtol(shift_parameter(possible_command).c_str(), NULL, 10);
             int tempval =  (int)strtol(shift_parameter(possible_command).c_str(), NULL, 10);
 
-            THEKERNEL->modbus->write_holding_register(19, regaddr, tempval);
+            THEKERNEL->modbus->write_holding_register(1, regaddr, tempval);
+            THEKERNEL->streams->printf("Setting bed modbus bed reg %d to %d\r\n", regaddr, tempval);
+        }
+        else if (cmd == "readbed"){
+            int regaddr =  (int)strtol(shift_parameter(possible_command).c_str(), NULL, 10);
+            int val = THEKERNEL->modbus->read_holding_register(1, regaddr);
+            THEKERNEL->streams->printf("modbus bed reg %d reads %d\r\n", regaddr, val);
         }
     }
 }

--- a/src/modules/JuicyBoard/R1000A_MODBUS/BufferedSoftSerial.cpp
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/BufferedSoftSerial.cpp
@@ -1,0 +1,140 @@
+/**
+ * @file    BufferedSoftSerial.cpp
+ * @brief   Software Buffer - Extends mbed Serial functionallity adding irq driven TX and RX
+ * @author  sam grove
+ * @version 1.0
+ * @see
+ *
+ * Copyright (c) 2013
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BufferedSoftSerial.h"
+#include <stdarg.h>
+
+BufferedSoftSerial::BufferedSoftSerial(PinName tx, PinName rx, const char* name)
+    : SoftSerial(tx, rx, name)
+{
+    SoftSerial::attach(this, &BufferedSoftSerial::rxIrq, SoftSerial::RxIrq);
+
+    return;
+}
+
+int BufferedSoftSerial::readable(void)
+{
+    return _rxbuf.size();  // note: look if things are in the buffer
+}
+
+int BufferedSoftSerial::writeable(void)
+{
+    return 1;   // buffer allows overwriting by design, always true
+}
+
+int BufferedSoftSerial::getc(void)
+{
+    char retval;
+    _rxbuf.pop_front(retval);
+    return (int)retval;
+}
+
+int BufferedSoftSerial::putc(int c)
+{
+    _txbuf.push_back((char)c);
+    BufferedSoftSerial::prime();
+
+    return c;
+}
+
+int BufferedSoftSerial::puts(const char *s)
+{
+    const char* ptr = s;
+
+    while(*(ptr) != 0) {
+        _txbuf.push_back(*(ptr++));
+    }
+    _txbuf.push_back('\n');  // done per puts definition
+    BufferedSoftSerial::prime();
+
+    return (ptr - s) + 1;
+}
+
+int BufferedSoftSerial::printf(const char* format, ...)
+{
+    char buf[256] = {0};
+    int r = 0;
+
+    va_list arg;
+    va_start(arg, format);
+    r = vsprintf(buf, format, arg);
+    va_end(arg);
+    r = BufferedSoftSerial::write(buf, r);
+
+    return r;
+}
+
+ssize_t BufferedSoftSerial::write(const void *s, size_t length)
+{
+    const char* ptr = (const char*)s;
+    const char* end = ptr + length;
+
+    while (ptr != end) {
+        _txbuf.push_back(*(ptr++));
+    }
+    BufferedSoftSerial::prime();
+
+    return ptr - (const char*)s;
+}
+
+
+void BufferedSoftSerial::rxIrq(void)
+{
+    // read from the peripheral and make sure something is available
+    if(SoftSerial::readable()) {
+        _rxbuf.push_back(_getc()); // if so load them into a buffer
+    }
+
+    return;
+}
+
+void BufferedSoftSerial::txIrq(void)
+{
+    char retval;
+    // see if there is room in the hardware fifo and if something is in the software fifo
+    while(SoftSerial::writeable()) {
+        if(_txbuf.size()) {
+            _txbuf.pop_front(retval);
+            _putc((int)retval);
+        } else {
+            // disable the TX interrupt when there is nothing left to send
+            SoftSerial::attach(NULL, SoftSerial::TxIrq);
+            break;
+        }
+    }
+
+    return;
+}
+
+void BufferedSoftSerial::prime(void)
+{
+    // if already busy then the irq will pick this up
+    if(SoftSerial::writeable()) {
+        SoftSerial::attach(NULL, SoftSerial::TxIrq);    // make sure not to cause contention in the irq
+        BufferedSoftSerial::txIrq();                // only write to hardware in one place
+        SoftSerial::attach(this, &BufferedSoftSerial::txIrq, SoftSerial::TxIrq);
+    }
+
+    return;
+}
+
+

--- a/src/modules/JuicyBoard/R1000A_MODBUS/BufferedSoftSerial.h
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/BufferedSoftSerial.h
@@ -1,0 +1,98 @@
+
+/**
+ * @file    BufferedSoftSerial.h
+ * @brief   Software Buffer - Extends mbed Serial functionallity adding irq driven TX and RX
+ * @author  sam grove
+ * @version 1.0
+ * @see     
+ *
+ * Copyright (c) 2013
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BUFFEREDSOFTSERIAL_H
+#define BUFFEREDSOFTSERIAL_H
+ 
+#include "mbed.h"
+#include "libs/RingBuffer.h"
+#include "SoftSerial.h"
+
+/**
+ *  @class BufferedSerial
+ *  @brief Software buffers and interrupt driven tx and rx for SoftSerial
+ */  
+class BufferedSoftSerial : public SoftSerial 
+{
+private:
+
+     RingBuffer<char,32> _rxbuf;
+     RingBuffer<char,32> _txbuf;
+    //Buffer <char> _rxbuf;
+    //Buffer <char> _txbuf;
+ 
+    void rxIrq(void);
+    void txIrq(void);
+    void prime(void);
+    
+public:
+    /** Create a BufferedSoftSerial port, connected to the specified transmit and receive pins
+     *  @param tx Transmit pin
+     *  @param rx Receive pin
+     *  @note Either tx or rx may be specified as NC if unused
+     */
+    BufferedSoftSerial(PinName tx, PinName rx, const char* name=NULL);
+    
+    /** Check on how many bytes are in the rx buffer
+     *  @return 1 if something exists, 0 otherwise
+     */
+    virtual int readable(void);
+    
+    /** Check to see if the tx buffer has room
+     *  @return 1 always has room and can overwrite previous content if too small / slow
+     */
+    virtual int writeable(void);
+    
+    /** Get a single byte from the BufferedSoftSerial Port.
+     *  Should check readable() before calling this.
+     *  @return A byte that came in on the BufferedSoftSerial Port
+     */
+    virtual int getc(void);
+    
+    /** Write a single byte to the BufferedSoftSerial Port.
+     *  @param c The byte to write to the BufferedSoftSerial Port
+     *  @return The byte that was written to the BufferedSoftSerial Port Buffer
+     */
+    virtual int putc(int c);
+    
+    /** Write a string to the BufferedSoftSerial Port. Must be NULL terminated
+     *  @param s The string to write to the Serial Port
+     *  @return The number of bytes written to the Serial Port Buffer
+     */
+    virtual int puts(const char *s);
+    
+    /** Write a formatted string to the BufferedSoftSerial Port.
+     *  @param format The string + format specifiers to write to the BufferedSoftSerial Port
+     *  @return The number of bytes written to the Serial Port Buffer
+     */
+    virtual int printf(const char* format, ...);
+    
+    /** Write data to the BufferedSoftSerial Port
+     *  @param s A pointer to data to send
+     *  @param length The amount of data being pointed to
+     *  @return The number of bytes written to the Serial Port Buffer
+     */
+    virtual ssize_t write(const void *s, std::size_t length);
+};
+
+#endif

--- a/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.cpp
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.cpp
@@ -1,0 +1,288 @@
+/*
+ * R1000A_I2C.cpp
+ *
+ *  Created on: Sep 17, 2016
+ *      Author: sherifeid
+ */
+
+#include "mbed.h"
+#include "R1000A_MODBUS.h"
+#include "libs/Kernel.h"
+#include "libs/Module.h"
+#include "LPC1768/PinNames.h"
+
+R1000A_MODBUS::R1000A_MODBUS(){
+    // Default Constructor
+ 
+    //this->serial = new mbed::Serial(p25, p26);
+    //this->serial = new mbed::Serial(P2_1, P2_0);
+    
+    this->serial = new BufferedSoftSerial(P2_0, P2_1);
+    this->serial->baud(MODBUS_BAUD);
+    this->serial->format(MODBUS_DATABITS, serial->Parity::None, MODBUS_STOPBITS);
+}
+
+R1000A_MODBUS::~R1000A_MODBUS(){
+    // Destructor
+}
+
+// Called when the module has just been loaded
+void R1000A_MODBUS::on_module_loaded() {
+    // We want to be called every time a new char is received
+    
+    //this->serial->attach(this, &R1000A_MODBUS::on_serial_char_received, mbed::Serial::RxIrq);
+    //query_flag= false;
+    //halt_flag= false;
+
+    // We only call the command dispatcher in the main loop, nowhere else
+    //this->register_for_event(ON_MAIN_LOOP);
+    //this->register_for_event(ON_IDLE);
+
+    // Add to the pack of streams kernel can call to, for example for broadcasting
+    //THEKERNEL->streams->append_stream(this);
+}
+
+// Called on R1000A_MODBUS::RxIrq interrupt, meaning we have received a char
+void R1000A_MODBUS::on_serial_char_received(){
+    while(this->serial->readable()){
+        char received = this->serial->getc();
+        /*
+        if(received == '?') {
+            query_flag= true;
+            continue;
+        }
+        if(received == 'X'-'A'+1) { // ^X
+            halt_flag= true;
+            continue;
+        }
+        // convert CR to NL (for host OSs that don't send NL)
+        if( received == '\r' ){ received = '\n'; }
+        */
+
+        this->buffer.push_back(received);
+    }
+}
+
+int R1000A_MODBUS::puts(const char* s)
+{
+    //return fwrite(s, strlen(s), 1, (FILE*)(*this->serial));
+    size_t n= strlen(s);
+    for (size_t i = 0; i < n; ++i) {
+        _putc(s[i]);
+    }
+    return n;
+}
+
+void R1000A_MODBUS::send_test_string()
+{
+    char telegram[8];
+    telegram[0] = 'T';       // Slave address
+    telegram[1] = 'E';             // Function code
+    telegram[2] = 'S'; // Coil address MSB
+    telegram[3] = 'T'; // Coil address LSB
+    telegram[4] = '1';   // number of coils to read MSB
+    telegram[5] = '2';   // number of coils to read LSB  
+    telegram[6] = '\r';              // CRC LSB
+    telegram[7] = '\n';       // CRC MSB
+    this->serial->write(telegram, 8);
+    //for (int i=0; i<8; i++){
+    //    _putc(telegram[i]);
+    //}
+}
+
+int R1000A_MODBUS::_putc(int c)
+{
+    return this->serial->putc(c);
+}
+
+int R1000A_MODBUS::_getc()
+{
+    return this->serial->getc();
+}
+
+/*
+
+int R1000A_I2C::I2C_ReadREG(int slotnum, char REGAddr, char * data, int length){
+    // perform burst register read
+    int i;                                      // for loop variable
+    char I2CAddr = getSlotI2CAdd(slotnum);      // get slot I2C address
+    // set the register to access
+    this->i2c->start();
+    if (this->i2c->write(I2CAddr) != 1){        // check for slave ack
+        // slave I2C is not acknowledging, exit function
+        this->i2c->stop();
+        return -1;
+    }
+    this->i2c->write(REGAddr);                  // register address
+    this->i2c->stop();
+
+    // read part
+    this->i2c->start();
+    this->i2c->write(I2CAddr | 0x01);           // slave I2C address, with read command
+    for (i=0; i<length; i++){                   // loop over every byte
+        data[i] = this->i2c->read(1);
+    }
+    this->i2c->read(0);                         // extra dummy read for mbed I2C to stop properly
+    this->i2c->stop();
+    return 0;
+}
+
+int R1000A_I2C::I2C_Read(int slotnum, char * data, int length){
+    // perform burst register read
+    int i;                                      // for loop variable
+    char I2CAddr = getSlotI2CAdd(slotnum);      // get slot I2C address
+    // set the register to access
+    this->i2c->start();
+    if (this->i2c->write(I2CAddr | 0x01) != 1){        // check for slave ack // slave I2C address, with read command
+        // slave I2C is not acknowledging, exit function
+        this->i2c->stop();
+        return -1;
+    }
+    for (i=0; i<length; i++){                   // loop over every byte
+        data[i] = this->i2c->read(1);
+    }
+    this->i2c->read(0);                         // extra dummy read for mbed I2C to stop properly
+    this->i2c->stop();
+    return 0;
+}
+
+int R1000A_I2C::I2C_WriteREG(int slotnum, char REGAddr, char * data, int length){
+    // perform burst register read
+    int i;                                      // for loop variable
+    char I2CAddr = getSlotI2CAdd(slotnum);     // get slot I2C address
+    // set the register to access
+    this->i2c->start();
+    if (this->i2c->write(I2CAddr) != 1){        // check for slave ack
+        // slave I2C is not acknowledging, exit function
+        this->i2c->stop();
+        return -1;
+    }
+    this->i2c->write(REGAddr);                  // register address
+    for (i=0; i<length; i++){
+        this->i2c->write(data[i]);              // write data one by one
+    }
+    this->i2c->stop();
+    return 0;
+}
+
+int R1000A_I2C::I2C_CheckAddr(char I2CAddr){
+    // check if I2C address acknowledges
+    // set the register to access
+    this->i2c->start();
+    if (this->i2c->write((I2CAddr << 1) | 0x01) != 1){        // check for slave ack
+        // slave I2C is not acknowledging, exit function
+        this->i2c->stop();
+        return -1;
+    }
+    else
+    {
+        this->i2c->stop();
+        return 0;
+    }
+}
+
+int R1000A_I2C::I2C_CheckAck(int slotnum){
+    // checks mounted in the given slot acknowledges
+    // set the register to access
+
+    char I2CAddr = getSlotI2CAdd(slotnum);     // get slot I2C address
+    this->i2c->start();
+    if (this->i2c->write(I2CAddr) != 1){        // check for slave ack
+        // slave I2C is not acknowledging, exit function
+        this->i2c->stop();
+        return -1;
+    }
+    else{
+        this->i2c->stop();
+        return 0;
+    }
+}
+
+int R1000A_I2C::I2C_CheckBLMode(int slotnum){
+    // checks mounted in the given slot acknowledges
+    // set the register to access
+    // returns:
+    //      0 : if module is in bootloader mode
+    //     -1 : I2C error, module didn't ack
+    //     -2 : module is not in bootloader mode
+
+    char i2cbuf[2];
+
+    if (I2C_ReadREG(slotnum,TGT_CMD_CHECK_BLSTAT,i2cbuf,1)==0){
+        // now read BLSTAT register
+        if (i2cbuf[0] == TGT_RSP_BL_MODE){
+
+            return 0;       // module in bootloader mode
+        }
+        else{
+            return -2;      // module not in bootloader mode
+        }
+    }
+    else{
+        return -1;          // I2C ack error
+    }
+}
+
+char R1000A_I2C::getSlotI2CAdd(int slotnum){
+    // returns I2C address of the specific slot
+    // This slot numbers are ordered as follows
+    // Slots 1~15 are pluggable modules
+    // Slot 100 is reserved for the power monitor chip
+    // Slot 200 is reserved for the EEPROM
+    if (slotnum == PWRMON_SLOT){
+        return (PWRMON_BASE << 1);
+    }
+    else if ((slotnum >= EEPROM_SLOT_BASE) && (slotnum < (EEPROM_SLOT_BASE + EEPROM_NUM_SLOTS))){
+        // this returns the address of EEPROM section, limit is 4 sections x 256 bytes
+        return ((EEPROM_I2C_BASE + slotnum - EEPROM_SLOT_BASE) << 1);
+    }
+    else{
+        return ((R1000_I2C_BASE + slotnum - 1) << 1);
+    }
+}
+
+void R1000A_I2C::enablemodI2C(void){
+    modI2Cenabled = true;
+}
+
+void R1000A_I2C::disablemodI2C(void){
+    modI2Cenabled = false;
+}
+
+int R1000A_I2C::ismodI2Cenabled(void){
+
+    if (modI2Cenabled){
+        return 1;
+    }
+    else{
+        return 0;
+    }
+}
+
+float R1000A_I2C::I2C_ReadREGfloat (int slotnum, char REGAddr){
+    // This function reads 4 bytes from the give slot/register
+    // processes the data and returns a 'float' value
+
+    // first create a union to translate between values
+    union tempdata {
+        float f;
+        char c[4];
+    };
+
+    char i2cbuf[4];
+    union tempdata chtemp;
+
+    if (I2C_ReadREG(slotnum,REGAddr,i2cbuf,4) == 0){
+        chtemp.c[3] = i2cbuf[0];
+        chtemp.c[2] = i2cbuf[1];
+        chtemp.c[1] = i2cbuf[2];
+        chtemp.c[0] = i2cbuf[3];
+        return chtemp.f;
+    }
+    else{
+        // I2C error, still need to return a value
+        return 0;
+    }
+}
+
+*/

--- a/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.cpp
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.cpp
@@ -130,7 +130,7 @@ void R1000A_MODBUS::read_coil(int slave_addr, int coil_addr, int n_coils){
     // read and return data from buffer
 }
 
-int R1000A_MODBUS::read_holding_register(int slave_addr, int reg_addr){
+int R1000A_MODBUS::read_holding_register(int slave_addr, int reg_addr, int rdelay){
     char telegram[8];
     unsigned int crc;
     telegram[0] = slave_addr;       // Slave address
@@ -146,7 +146,7 @@ int R1000A_MODBUS::read_holding_register(int slave_addr, int reg_addr){
     serial->write(telegram,8);
     delay((int) ceil(8 * delay_time));
     dir_output->clear();
-    delay((int) ceil(100 + 8 * delay_time));            // readlion needs an extra 100ms delay!!
+    delay((int) ceil(rdelay + 8 * delay_time));            // readlion needs an extra 100ms delay!!
 
     int buffin[12];                 // oversized buffer
     for (int i = 0; i < 8; i++){

--- a/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.cpp
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.cpp
@@ -146,13 +146,7 @@ int R1000A_MODBUS::read_holding_register(int slave_addr, int reg_addr){
     serial->write(telegram,8);
     delay((int) ceil(8 * delay_time));
     dir_output->clear();
-    delay((int) ceil(100 + 8 * delay_time));
-
-    //delay((int) ceil(50 + 8 * delay_time));     // wait for buffer to receive data from slave
-    /*
-    while (serial->readable() < 7){
-        // stick here until some characters are available
-    }*/
+    delay((int) ceil(100 + 8 * delay_time));            // readlion needs an extra 100ms delay!!
 
     int buffin[12];                 // oversized buffer
     for (int i = 0; i < 8; i++){
@@ -160,30 +154,7 @@ int R1000A_MODBUS::read_holding_register(int slave_addr, int reg_addr){
             if (serial->readable() != 0)
                 buffin[i] = serial->getc();
         }
-
     return (buffin[3] << 8) | buffin[4];
-       
-    /*
-    if (serial->readable() > 0) {
-        // buffer has data, read and process
-        int buffin[8];
-        for (int i = 0; i < 0; i++){
-            // read characters from buffer
-            buffin[i] = serial->getc();
-        }
-
-        return buffin[4];
-    }
-    else
-    {
-        return -999;
-    }
-    */
-    
-
-    // TODO: read reply from buffer and return it
-    // add delay for slave to respond
-    // read and return data from buffer
 }
 
 void R1000A_MODBUS::write_coil(int slave_addr, int coil_addr, bool data){

--- a/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.cpp
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.cpp
@@ -11,15 +11,54 @@
 #include "libs/Module.h"
 #include "LPC1768/PinNames.h"
 
-R1000A_MODBUS::R1000A_MODBUS(){
+R1000A_MODBUS::R1000A_MODBUS(int slotnum, int baudrate, int databits, int stopbits, string _parity){
     // Default Constructor
  
     //this->serial = new mbed::Serial(p25, p26);
     //this->serial = new mbed::Serial(P2_1, P2_0);
+
+    this->enabled = true;
+
+    PinName tx_pin, rx_pin, dir_pin;
+    switch (slotnum){
+        // slots not working are commented out
+        //case 1  : tx_pin = P1_30; rx_pin = P1_31; dir_pin = P0_23; break;
+        case 2  : tx_pin = P2_0 ; rx_pin = P2_1 ; dir_pin = P2_2 ; break;
+        //case 3  : tx_pin = P1_22; rx_pin = P1_23; dir_pin = P1_24; break;
+        //case 4  : tx_pin = P1_26; rx_pin = P1_27; dir_pin = P1_28; break;
+        //case 5  : tx_pin = P0_10; rx_pin = P0_11; dir_pin = P0_1 ; break;
+        case 6  : tx_pin = P3_25; rx_pin = P2_11; dir_pin = P2_12; break;
+        case 7  : tx_pin = P0_19; rx_pin = P0_20; dir_pin = P0_21; break;
+        //case 8  : tx_pin = P0_2 ; rx_pin = P0_3 ; dir_pin = P0_26; break;
+        //case 9  : tx_pin = P0_15; rx_pin = P0_16; dir_pin = P0_17; break;
+        case 10 : tx_pin = P2_4 ; rx_pin = P2_5 ; dir_pin = P2_6 ; break;
+        //case 11 : tx_pin = P1_18; rx_pin = P1_19; dir_pin = P1_20; break;
+        //case 12 : tx_pin = P4_28; rx_pin = P4_29; dir_pin = P0_4 ; break;
+        //case 13 : tx_pin = P1_1 ; rx_pin = P1_0 ; dir_pin = P3_26; break;
+        //case 14 : tx_pin = P1_14; rx_pin = P1_15; dir_pin = P1_16; break;
+        //case 15 : tx_pin = P1_4 ; rx_pin = P1_8 ; dir_pin = P1_9 ; break;
+        default : tx_pin = NC   ; rx_pin = NC   ; dir_pin = NC   ; break;
+    }
     
-    this->serial = new BufferedSoftSerial(P2_0, P2_1);
-    this->serial->baud(MODBUS_BAUD);
-    this->serial->format(MODBUS_DATABITS, serial->Parity::None, MODBUS_STOPBITS);
+    this->serial = new BufferedSoftSerial(tx_pin, rx_pin);
+    this->serial->baud(baudrate);
+
+    if (_parity == "O"){
+        this->serial->format(databits,serial->Parity::Odd,stopbits);
+        calculate_delay(baudrate, databits, 1, stopbits);
+    }
+    else if (_parity == "E"){
+        this->serial->format(databits,serial->Parity::Even,stopbits);
+        calculate_delay(baudrate, databits, 1, stopbits);
+    }
+    else{
+        this->serial->format(databits,serial->Parity::None,stopbits);
+        calculate_delay(baudrate, databits, 0, stopbits);
+    }
+
+    dir_output = new GPIO(dir_pin);
+    dir_output->output();
+    dir_output->clear();
 }
 
 R1000A_MODBUS::~R1000A_MODBUS(){
@@ -29,48 +68,12 @@ R1000A_MODBUS::~R1000A_MODBUS(){
 // Called when the module has just been loaded
 void R1000A_MODBUS::on_module_loaded() {
     // We want to be called every time a new char is received
-    
-    //this->serial->attach(this, &R1000A_MODBUS::on_serial_char_received, mbed::Serial::RxIrq);
-    //query_flag= false;
-    //halt_flag= false;
-
-    // We only call the command dispatcher in the main loop, nowhere else
-    //this->register_for_event(ON_MAIN_LOOP);
-    //this->register_for_event(ON_IDLE);
-
-    // Add to the pack of streams kernel can call to, for example for broadcasting
-    //THEKERNEL->streams->append_stream(this);
+    serial->attach(this, &R1000A_MODBUS::on_serial_char_received, BufferedSoftSerial::RxIrq);
 }
 
-// Called on R1000A_MODBUS::RxIrq interrupt, meaning we have received a char
+// Called on Serial::RxIrq interrupt, meaning we have received a char
 void R1000A_MODBUS::on_serial_char_received(){
-    while(this->serial->readable()){
-        char received = this->serial->getc();
-        /*
-        if(received == '?') {
-            query_flag= true;
-            continue;
-        }
-        if(received == 'X'-'A'+1) { // ^X
-            halt_flag= true;
-            continue;
-        }
-        // convert CR to NL (for host OSs that don't send NL)
-        if( received == '\r' ){ received = '\n'; }
-        */
-
-        this->buffer.push_back(received);
-    }
-}
-
-int R1000A_MODBUS::puts(const char* s)
-{
-    //return fwrite(s, strlen(s), 1, (FILE*)(*this->serial));
-    size_t n= strlen(s);
-    for (size_t i = 0; i < n; ++i) {
-        _putc(s[i]);
-    }
-    return n;
+    buffer.push_back(serial->getc());
 }
 
 void R1000A_MODBUS::send_test_string()
@@ -80,209 +83,136 @@ void R1000A_MODBUS::send_test_string()
     telegram[1] = 'E';             // Function code
     telegram[2] = 'S'; // Coil address MSB
     telegram[3] = 'T'; // Coil address LSB
-    telegram[4] = '1';   // number of coils to read MSB
-    telegram[5] = '2';   // number of coils to read LSB  
+    telegram[4] = '.';   // number of coils to read MSB
+    telegram[5] = '.';   // number of coils to read LSB  
     telegram[6] = '\r';              // CRC LSB
     telegram[7] = '\n';       // CRC MSB
     this->serial->write(telegram, 8);
-    //for (int i=0; i<8; i++){
-    //    _putc(telegram[i]);
-    //}
 }
 
-int R1000A_MODBUS::_putc(int c)
-{
-    return this->serial->putc(c);
+void R1000A_MODBUS::calculate_delay(int baudrate, int bits, int parity, int stop) {
+
+    float bittime = 1000.0 / baudrate;
+    // here we calculate how long a byte with all surrounding bits take
+    // startbit + number of bits + parity bit + stop bit
+    delay_time = bittime * (1 + bits + parity + 1);
 }
 
-int R1000A_MODBUS::_getc()
-{
-    return this->serial->getc();
+void R1000A_MODBUS::delay(unsigned int value) {
+    uint32_t start = us_ticker_read(); // mbed call
+    while ((us_ticker_read() - start) < value*1000) {
+        THEKERNEL->call_event(ON_IDLE, this);
+    }
+
 }
 
-/*
-
-int R1000A_I2C::I2C_ReadREG(int slotnum, char REGAddr, char * data, int length){
-    // perform burst register read
-    int i;                                      // for loop variable
-    char I2CAddr = getSlotI2CAdd(slotnum);      // get slot I2C address
-    // set the register to access
-    this->i2c->start();
-    if (this->i2c->write(I2CAddr) != 1){        // check for slave ack
-        // slave I2C is not acknowledging, exit function
-        this->i2c->stop();
-        return -1;
-    }
-    this->i2c->write(REGAddr);                  // register address
-    this->i2c->stop();
-
-    // read part
-    this->i2c->start();
-    this->i2c->write(I2CAddr | 0x01);           // slave I2C address, with read command
-    for (i=0; i<length; i++){                   // loop over every byte
-        data[i] = this->i2c->read(1);
-    }
-    this->i2c->read(0);                         // extra dummy read for mbed I2C to stop properly
-    this->i2c->stop();
-    return 0;
+void R1000A_MODBUS::read_coil(int slave_addr, int coil_addr, int n_coils){
+    char telegram[8];
+    unsigned int crc;
+    telegram[0] = slave_addr;       // Slave address
+    telegram[1] = 0x01;             // Function code
+    telegram[2] = (coil_addr >> 8); // Coil address MSB
+    telegram[3] = coil_addr & 0xFF; // Coil address LSB
+    telegram[4] = (n_coils >> 8);   // number of coils to read MSB
+    telegram[5] = n_coils & 0xFF;   // number of coils to read LSB
+    crc = crc16(telegram, 6);       
+    telegram[6] = crc;              // CRC LSB
+    telegram[7] = (crc >> 8);       // CRC MSB
+    dir_output->set();
+    serial->write(telegram,8);
+    delay((int) ceil(50 + 8 * delay_time));
+    dir_output->clear();
+    // TODO: read reply from buffer and return it
 }
 
-int R1000A_I2C::I2C_Read(int slotnum, char * data, int length){
-    // perform burst register read
-    int i;                                      // for loop variable
-    char I2CAddr = getSlotI2CAdd(slotnum);      // get slot I2C address
-    // set the register to access
-    this->i2c->start();
-    if (this->i2c->write(I2CAddr | 0x01) != 1){        // check for slave ack // slave I2C address, with read command
-        // slave I2C is not acknowledging, exit function
-        this->i2c->stop();
-        return -1;
-    }
-    for (i=0; i<length; i++){                   // loop over every byte
-        data[i] = this->i2c->read(1);
-    }
-    this->i2c->read(0);                         // extra dummy read for mbed I2C to stop properly
-    this->i2c->stop();
-    return 0;
+void R1000A_MODBUS::read_holding_register(int slave_addr, int reg_addr, int n_regs){
+
+    // TODO: implement this
 }
 
-int R1000A_I2C::I2C_WriteREG(int slotnum, char REGAddr, char * data, int length){
-    // perform burst register read
-    int i;                                      // for loop variable
-    char I2CAddr = getSlotI2CAdd(slotnum);     // get slot I2C address
-    // set the register to access
-    this->i2c->start();
-    if (this->i2c->write(I2CAddr) != 1){        // check for slave ack
-        // slave I2C is not acknowledging, exit function
-        this->i2c->stop();
-        return -1;
-    }
-    this->i2c->write(REGAddr);                  // register address
-    for (i=0; i<length; i++){
-        this->i2c->write(data[i]);              // write data one by one
-    }
-    this->i2c->stop();
-    return 0;
+void R1000A_MODBUS::write_coil(int slave_addr, int coil_addr, bool data){
+    char telegram[8];
+    unsigned int crc;
+    telegram[0] = slave_addr;       // Slave address
+    telegram[1] = 0x05;             // Function code
+    telegram[2] = (coil_addr >> 8); // Coil address MSB
+    telegram[3] = coil_addr & 0xFF; // Coil address LSB
+    telegram[4] = 0x00;             // Data MSB
+    telegram[5] = (data == true) ? 0xFF : 0x00; // Data LSB
+    crc = crc16(telegram, 6);       
+    telegram[6] = crc;              // CRC LSB
+    telegram[7] = (crc >> 8);       // CRC MSB
+    dir_output->set();
+    serial->write(telegram,8);
+    delay((int) ceil(50 + 8 * delay_time));
+    dir_output->clear();
 }
 
-int R1000A_I2C::I2C_CheckAddr(char I2CAddr){
-    // check if I2C address acknowledges
-    // set the register to access
-    this->i2c->start();
-    if (this->i2c->write((I2CAddr << 1) | 0x01) != 1){        // check for slave ack
-        // slave I2C is not acknowledging, exit function
-        this->i2c->stop();
-        return -1;
-    }
-    else
-    {
-        this->i2c->stop();
-        return 0;
-    }
+
+void R1000A_MODBUS::write_holding_register(int slave_addr, int reg_addr, int data){
+    char telegram[8];
+    unsigned int crc;
+    telegram[0] = slave_addr;       // Slave address
+    telegram[1] = 0x06;             // Function code
+    telegram[2] = (reg_addr >> 8);  // Register address MSB
+    telegram[3] = reg_addr;         // Register address LSB
+    telegram[4] = (data >> 8);      // Data MSB
+    telegram[5] = data;             // Data LSB
+    crc = crc16(telegram, 6);       
+    telegram[6] = crc;              // CRC LSB
+    telegram[7] = (crc >> 8);       // CRC MSB
+    dir_output->set();
+    serial->write(telegram,8);
+    delay((int) ceil(50 + 8 * delay_time));
+    dir_output->clear();
 }
 
-int R1000A_I2C::I2C_CheckAck(int slotnum){
-    // checks mounted in the given slot acknowledges
-    // set the register to access
-
-    char I2CAddr = getSlotI2CAdd(slotnum);     // get slot I2C address
-    this->i2c->start();
-    if (this->i2c->write(I2CAddr) != 1){        // check for slave ack
-        // slave I2C is not acknowledging, exit function
-        this->i2c->stop();
-        return -1;
-    }
-    else{
-        this->i2c->stop();
-        return 0;
-    }
-}
-
-int R1000A_I2C::I2C_CheckBLMode(int slotnum){
-    // checks mounted in the given slot acknowledges
-    // set the register to access
-    // returns:
-    //      0 : if module is in bootloader mode
-    //     -1 : I2C error, module didn't ack
-    //     -2 : module is not in bootloader mode
-
-    char i2cbuf[2];
-
-    if (I2C_ReadREG(slotnum,TGT_CMD_CHECK_BLSTAT,i2cbuf,1)==0){
-        // now read BLSTAT register
-        if (i2cbuf[0] == TGT_RSP_BL_MODE){
-
-            return 0;       // module in bootloader mode
-        }
-        else{
-            return -2;      // module not in bootloader mode
-        }
-    }
-    else{
-        return -1;          // I2C ack error
-    }
-}
-
-char R1000A_I2C::getSlotI2CAdd(int slotnum){
-    // returns I2C address of the specific slot
-    // This slot numbers are ordered as follows
-    // Slots 1~15 are pluggable modules
-    // Slot 100 is reserved for the power monitor chip
-    // Slot 200 is reserved for the EEPROM
-    if (slotnum == PWRMON_SLOT){
-        return (PWRMON_BASE << 1);
-    }
-    else if ((slotnum >= EEPROM_SLOT_BASE) && (slotnum < (EEPROM_SLOT_BASE + EEPROM_NUM_SLOTS))){
-        // this returns the address of EEPROM section, limit is 4 sections x 256 bytes
-        return ((EEPROM_I2C_BASE + slotnum - EEPROM_SLOT_BASE) << 1);
-    }
-    else{
-        return ((R1000_I2C_BASE + slotnum - 1) << 1);
-    }
-}
-
-void R1000A_I2C::enablemodI2C(void){
-    modI2Cenabled = true;
-}
-
-void R1000A_I2C::disablemodI2C(void){
-    modI2Cenabled = false;
-}
-
-int R1000A_I2C::ismodI2Cenabled(void){
-
-    if (modI2Cenabled){
-        return 1;
-    }
-    else{
-        return 0;
-    }
-}
-
-float R1000A_I2C::I2C_ReadREGfloat (int slotnum, char REGAddr){
-    // This function reads 4 bytes from the give slot/register
-    // processes the data and returns a 'float' value
-
-    // first create a union to translate between values
-    union tempdata {
-        float f;
-        char c[4];
+unsigned int R1000A_MODBUS::crc16(char *data, unsigned int len) {
+    
+    static const unsigned short crc_table[] = {
+    0X0000, 0XC0C1, 0XC181, 0X0140, 0XC301, 0X03C0, 0X0280, 0XC241,
+    0XC601, 0X06C0, 0X0780, 0XC741, 0X0500, 0XC5C1, 0XC481, 0X0440,
+    0XCC01, 0X0CC0, 0X0D80, 0XCD41, 0X0F00, 0XCFC1, 0XCE81, 0X0E40,
+    0X0A00, 0XCAC1, 0XCB81, 0X0B40, 0XC901, 0X09C0, 0X0880, 0XC841,
+    0XD801, 0X18C0, 0X1980, 0XD941, 0X1B00, 0XDBC1, 0XDA81, 0X1A40,
+    0X1E00, 0XDEC1, 0XDF81, 0X1F40, 0XDD01, 0X1DC0, 0X1C80, 0XDC41,
+    0X1400, 0XD4C1, 0XD581, 0X1540, 0XD701, 0X17C0, 0X1680, 0XD641,
+    0XD201, 0X12C0, 0X1380, 0XD341, 0X1100, 0XD1C1, 0XD081, 0X1040,
+    0XF001, 0X30C0, 0X3180, 0XF141, 0X3300, 0XF3C1, 0XF281, 0X3240,
+    0X3600, 0XF6C1, 0XF781, 0X3740, 0XF501, 0X35C0, 0X3480, 0XF441,
+    0X3C00, 0XFCC1, 0XFD81, 0X3D40, 0XFF01, 0X3FC0, 0X3E80, 0XFE41,
+    0XFA01, 0X3AC0, 0X3B80, 0XFB41, 0X3900, 0XF9C1, 0XF881, 0X3840,
+    0X2800, 0XE8C1, 0XE981, 0X2940, 0XEB01, 0X2BC0, 0X2A80, 0XEA41,
+    0XEE01, 0X2EC0, 0X2F80, 0XEF41, 0X2D00, 0XEDC1, 0XEC81, 0X2C40,
+    0XE401, 0X24C0, 0X2580, 0XE541, 0X2700, 0XE7C1, 0XE681, 0X2640,
+    0X2200, 0XE2C1, 0XE381, 0X2340, 0XE101, 0X21C0, 0X2080, 0XE041,
+    0XA001, 0X60C0, 0X6180, 0XA141, 0X6300, 0XA3C1, 0XA281, 0X6240,
+    0X6600, 0XA6C1, 0XA781, 0X6740, 0XA501, 0X65C0, 0X6480, 0XA441,
+    0X6C00, 0XACC1, 0XAD81, 0X6D40, 0XAF01, 0X6FC0, 0X6E80, 0XAE41,
+    0XAA01, 0X6AC0, 0X6B80, 0XAB41, 0X6900, 0XA9C1, 0XA881, 0X6840,
+    0X7800, 0XB8C1, 0XB981, 0X7940, 0XBB01, 0X7BC0, 0X7A80, 0XBA41,
+    0XBE01, 0X7EC0, 0X7F80, 0XBF41, 0X7D00, 0XBDC1, 0XBC81, 0X7C40,
+    0XB401, 0X74C0, 0X7580, 0XB541, 0X7700, 0XB7C1, 0XB681, 0X7640,
+    0X7200, 0XB2C1, 0XB381, 0X7340, 0XB101, 0X71C0, 0X7080, 0XB041,
+    0X5000, 0X90C1, 0X9181, 0X5140, 0X9301, 0X53C0, 0X5280, 0X9241,
+    0X9601, 0X56C0, 0X5780, 0X9741, 0X5500, 0X95C1, 0X9481, 0X5440,
+    0X9C01, 0X5CC0, 0X5D80, 0X9D41, 0X5F00, 0X9FC1, 0X9E81, 0X5E40,
+    0X5A00, 0X9AC1, 0X9B81, 0X5B40, 0X9901, 0X59C0, 0X5880, 0X9841,
+    0X8801, 0X48C0, 0X4980, 0X8941, 0X4B00, 0X8BC1, 0X8A81, 0X4A40,
+    0X4E00, 0X8EC1, 0X8F81, 0X4F40, 0X8D01, 0X4DC0, 0X4C80, 0X8C41,
+    0X4400, 0X84C1, 0X8581, 0X4540, 0X8701, 0X47C0, 0X4680, 0X8641,
+    0X8201, 0X42C0, 0X4380, 0X8341, 0X4100, 0X81C1, 0X8081, 0X4040
     };
 
-    char i2cbuf[4];
-    union tempdata chtemp;
+    unsigned char tmp;
+    unsigned short crc = 0xFFFF;
 
-    if (I2C_ReadREG(slotnum,REGAddr,i2cbuf,4) == 0){
-        chtemp.c[3] = i2cbuf[0];
-        chtemp.c[2] = i2cbuf[1];
-        chtemp.c[1] = i2cbuf[2];
-        chtemp.c[0] = i2cbuf[3];
-        return chtemp.f;
+    while(len--) {
+        tmp = *data++ ^ crc;
+        crc = crc >> 8;
+        crc ^= crc_table[tmp];
     }
-    else{
-        // I2C error, still need to return a value
-        return 0;
-    }
+
+    return crc;
+
 }
-
-*/

--- a/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.h
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.h
@@ -12,58 +12,36 @@
 #define MODBUS_DATABITS     8
 #define MODBUS_STOPBITS     1       
 
-#include "Serial.h" // mbed.h lib
 #include "BufferedSoftSerial.h"
-#include "libs/RingBuffer.h"
+#include "libs/gpio.h"
+#include <vector>
+#include <string>
 
 // This is an I2C wrapper class for low level I2C commands
 class R1000A_MODBUS {
     public:
-        // Default Constructor
-        R1000A_MODBUS();
+        R1000A_MODBUS(int slotnum, int baudrate, int databits, int stopbits, string _parity);
+        ~R1000A_MODBUS();                       
 
-        // Destructor
-        ~R1000A_MODBUS();
-
-        void on_module_loaded();                        // 
-        void on_serial_char_received();
-
-        // low level I2C operations
-        //int I2C_ReadREG(int, char, char*, int);         // burst read (using slotnum)
-        //int I2C_WriteREG(int, char, char*, int);        // burst write (using slotnum)
-        //int I2C_Read(int, char*, int);                  // burst read (using slotnum) current register
-        //float I2C_ReadREGfloat(int, char);              // reads a floating number (4 bytes) from the given slot/register
-
-        //int I2C_CheckAddr(char);                        // checks if I2C address acknowledges
-        //int I2C_CheckAck(int);                          // checks if slot acknowledges
-        //int I2C_CheckBLMode(int);                       // checks if the slot is in bootloader mode
-
-        // enable/disable/status for module I2C functions
-        // This is used to enable and module I2C functions other than module bootloader I2C
-        //void enablemodI2C(void);
-        //void disablemodI2C(void);
-        //int ismodI2Cenabled(void);
-
-        int _putc(int c);
-        int _getc(void);
-        int puts(const char*);
-
+        void on_module_loaded();     
+        void on_serial_char_received();       
         void send_test_string();        //FIXME: delete this after test
 
-        RingBuffer<char,256> buffer;                    // Receive buffer
-        //mbed::Serial* serial;
-        BufferedSoftSerial* serial;
+        void calculate_delay(int baudrate, int bits, int parity, int stop);
+        void delay(unsigned int);
 
-        struct {
-          bool query_flag:1;
-          bool halt_flag:1;
-        };
+        void read_coil(int slave_addr, int coil_addr, int n_coils);
+        void read_holding_register(int slave_addr, int reg_addr, int n_regs);
+        void write_coil(int slave_addr, int coil_addr, bool data);
+        void write_holding_register(int slave_addr, int reg_addr, int data);
+        unsigned int crc16(char *data, unsigned int len); 
 
     private:
-        // Member variables
-        //mbed::I2C* i2c;                                 // i2c comm class
-        //char getSlotI2CAdd(int);                        // returns I2C address from slot number
-        //bool modI2Cenabled;                             // a flag to show if normal module I2C operation is enabled
+        BufferedSoftSerial* serial;
+        std::vector<int> buffer;
+        GPIO *dir_output;
+        float delay_time;
+        bool enabled;
 };
 
 #endif /* SRC_MODULES_JUICYBOARD_R1000A_I2C_R1000A_MODBUS_H_ */

--- a/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.h
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.h
@@ -31,7 +31,7 @@ class R1000A_MODBUS {
         void delay(unsigned int);
 
         void read_coil(int slave_addr, int coil_addr, int n_coils);
-        int read_holding_register(int slave_addr, int reg_addr);
+        int read_holding_register(int slave_addr, int reg_addr, int rdelay);
         void write_coil(int slave_addr, int coil_addr, bool data);
         void write_holding_register(int slave_addr, int reg_addr, int data);
         unsigned int crc16(char *data, unsigned int len); 

--- a/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.h
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.h
@@ -31,7 +31,7 @@ class R1000A_MODBUS {
         void delay(unsigned int);
 
         void read_coil(int slave_addr, int coil_addr, int n_coils);
-        void read_holding_register(int slave_addr, int reg_addr, int n_regs);
+        int read_holding_register(int slave_addr, int reg_addr);
         void write_coil(int slave_addr, int coil_addr, bool data);
         void write_holding_register(int slave_addr, int reg_addr, int data);
         unsigned int crc16(char *data, unsigned int len); 

--- a/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.h
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/R1000A_MODBUS.h
@@ -1,0 +1,69 @@
+/*
+ * R1000A_I2C.h
+ *
+ *  Created on: Sep 17, 2016
+ *      Author: sherifeid
+ */
+
+#ifndef SRC_MODULES_JUICYBOARD_R1000A_I2C_R1000A_MODBUS_H_
+#define SRC_MODULES_JUICYBOARD_R1000A_I2C_R1000A_MODBUS_H_
+
+#define MODBUS_BAUD         9600       // I2C frequency
+#define MODBUS_DATABITS     8
+#define MODBUS_STOPBITS     1       
+
+#include "Serial.h" // mbed.h lib
+#include "BufferedSoftSerial.h"
+#include "libs/RingBuffer.h"
+
+// This is an I2C wrapper class for low level I2C commands
+class R1000A_MODBUS {
+    public:
+        // Default Constructor
+        R1000A_MODBUS();
+
+        // Destructor
+        ~R1000A_MODBUS();
+
+        void on_module_loaded();                        // 
+        void on_serial_char_received();
+
+        // low level I2C operations
+        //int I2C_ReadREG(int, char, char*, int);         // burst read (using slotnum)
+        //int I2C_WriteREG(int, char, char*, int);        // burst write (using slotnum)
+        //int I2C_Read(int, char*, int);                  // burst read (using slotnum) current register
+        //float I2C_ReadREGfloat(int, char);              // reads a floating number (4 bytes) from the given slot/register
+
+        //int I2C_CheckAddr(char);                        // checks if I2C address acknowledges
+        //int I2C_CheckAck(int);                          // checks if slot acknowledges
+        //int I2C_CheckBLMode(int);                       // checks if the slot is in bootloader mode
+
+        // enable/disable/status for module I2C functions
+        // This is used to enable and module I2C functions other than module bootloader I2C
+        //void enablemodI2C(void);
+        //void disablemodI2C(void);
+        //int ismodI2Cenabled(void);
+
+        int _putc(int c);
+        int _getc(void);
+        int puts(const char*);
+
+        void send_test_string();        //FIXME: delete this after test
+
+        RingBuffer<char,256> buffer;                    // Receive buffer
+        //mbed::Serial* serial;
+        BufferedSoftSerial* serial;
+
+        struct {
+          bool query_flag:1;
+          bool halt_flag:1;
+        };
+
+    private:
+        // Member variables
+        //mbed::I2C* i2c;                                 // i2c comm class
+        //char getSlotI2CAdd(int);                        // returns I2C address from slot number
+        //bool modI2Cenabled;                             // a flag to show if normal module I2C operation is enabled
+};
+
+#endif /* SRC_MODULES_JUICYBOARD_R1000A_I2C_R1000A_MODBUS_H_ */

--- a/src/modules/JuicyBoard/R1000A_MODBUS/SoftSerial.cpp
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/SoftSerial.cpp
@@ -1,0 +1,47 @@
+/* 
+ * SoftSerial by Erik Olieman
+ * Date: 05 Jul 2014
+ * Revision: 10:236fce2e5b8c
+ * URL: http://developer.mbed.org/users/Sissors/code/SoftSerial/
+ */
+
+#include "SoftSerial.h"
+
+SoftSerial::SoftSerial(PinName TX, PinName RX, const char* name) {
+    tx_en = rx_en = false;
+    if (TX != NC) {
+        tx = new DigitalOut(TX);
+        tx_en = true;
+        tx->write(1);
+        tx_bit = -1;
+        txticker.attach(this, &SoftSerial::tx_handler);
+    }
+    if (RX != NC) {
+        rx = new InterruptIn(RX);
+        rx_en = true;
+        out_valid = false;
+        rxticker.attach(this, &SoftSerial::rx_handler);
+        rx->fall(this, &SoftSerial::rx_gpio_irq_handler);
+    }
+    
+    baud(9600);
+    format();
+}
+
+SoftSerial::~SoftSerial() {
+    if (tx_en)
+        delete(tx);
+    if (rx_en)
+        delete(rx);
+}
+
+void SoftSerial::baud(int baudrate) {
+    bit_period = 1000000 / baudrate;
+}
+
+void SoftSerial::format(int bits, Parity parity, int stop_bits) {
+    _bits = bits;
+    _parity = parity;
+    _stop_bits = stop_bits;
+    _total_bits = 1 + _bits + _stop_bits + (bool)_parity;
+}

--- a/src/modules/JuicyBoard/R1000A_MODBUS/SoftSerial.h
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/SoftSerial.h
@@ -1,0 +1,127 @@
+/* 
+ * SoftSerial by Erik Olieman
+ * Date: 05 Jul 2014
+ * Revision: 10:236fce2e5b8c
+ * URL: http://developer.mbed.org/users/Sissors/code/SoftSerial/
+ */
+
+#ifndef SOFTSERIAL_H
+#define SOFTSERIAL_H
+
+#include "mbed.h"
+#include "SoftSerial_Ticker.h"
+/** A software serial implementation
+ *
+ */
+class SoftSerial: public Stream {
+
+public:
+    /**
+    * Constructor
+    *
+    * @param TX Name of the TX pin, NC for not connected
+    * @param RX Name of the RX pin, NC for not connected, must be capable of being InterruptIn
+    * @param name Name of the connection
+    */
+    SoftSerial(PinName TX, PinName RX, const char* name = NULL);
+    virtual ~SoftSerial();
+    
+    /** Set the baud rate of the serial port
+     *
+     *  @param baudrate The baudrate of the serial port (default = 9600).
+     */
+    void baud(int baudrate);
+
+    enum Parity {
+        None = 0,
+        Odd,
+        Even,
+        Forced1,
+        Forced0
+    };
+
+    enum IrqType {
+        RxIrq = 0,
+        TxIrq
+    };
+
+    /** Set the transmission format used by the serial port
+     *
+     *  @param bits The number of bits in a word (default = 8)
+     *  @param parity The parity used (SerialBase::None, SerialBase::Odd, SerialBase::Even, SerialBase::Forced1, SerialBase::Forced0; default = SerialBase::None)
+     *  @param stop The number of stop bits (default = 1)
+     */
+    void format(int bits=8, Parity parity=SoftSerial::None, int stop_bits=1);
+
+    /** Determine if there is a character available to read
+     *
+     *  @returns
+     *    1 if there is a character available to read,
+     *    0 otherwise
+     */
+    int readable();
+
+    /** Determine if there is space available to write a character
+     *
+     *  @returns
+     *    1 if there is space to write a character,
+     *    0 otherwise
+     */
+    int writeable();
+
+    /** Attach a function to call whenever a serial interrupt is generated
+     *
+     *  @param fptr A pointer to a void function, or 0 to set as none
+     *  @param type Which serial interrupt to attach the member function to (Seriall::RxIrq for receive, TxIrq for transmit buffer empty)
+     */
+    void attach(void (*fptr)(void), IrqType type=RxIrq) {
+        fpointer[type].attach(fptr);
+    }
+
+    /** Attach a member function to call whenever a serial interrupt is generated
+     *
+     *  @param tptr pointer to the object to call the member function on
+     *  @param mptr pointer to the member function to be called
+     *  @param type Which serial interrupt to attach the member function to (Seriall::RxIrq for receive, TxIrq for transmit buffer empty)
+     */
+    template<typename T>
+    void attach(T* tptr, void (T::*mptr)(void), IrqType type=RxIrq) {
+        fpointer[type].attach(tptr, mptr);
+    }
+
+protected:
+    DigitalOut *tx;
+    InterruptIn *rx;
+    
+    bool tx_en, rx_en;
+    int bit_period;
+    int _bits, _stop_bits, _total_bits;
+    Parity _parity;
+    
+    FunctionPointer fpointer[2];
+    
+    //rx
+    void rx_gpio_irq_handler(void);
+    void rx_handler(void);
+    int read_buffer, rx_bit;
+    volatile int out_buffer;
+    volatile bool out_valid;
+    bool rx_error;
+    FlexTicker rxticker;
+    
+    //tx
+    void tx_handler(void);
+    void prepare_tx(int c);
+    FlexTicker txticker;
+    int _char;
+    volatile int tx_bit;
+    
+    
+    
+    virtual int _getc();
+    virtual int _putc(int c);
+};
+
+
+#endif
+

--- a/src/modules/JuicyBoard/R1000A_MODBUS/SoftSerial_Ticker.h
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/SoftSerial_Ticker.h
@@ -1,0 +1,45 @@
+/* 
+ * SoftSerial by Erik Olieman
+ * Date: 05 Jul 2014
+ * Revision: 10:236fce2e5b8c
+ * URL: http://developer.mbed.org/users/Sissors/code/SoftSerial/
+ */
+
+//A modified version of the regular ticker/timeout libraries to allow us to do timeout without losing accuracy
+
+#ifndef FLEXTICKER_H
+#define FLEXTICKER_H
+
+#include "mbed.h"
+
+class FlexTicker: public TimerEvent {
+    public:
+    template<typename T>
+    void attach(T* tptr, void (T::*mptr)(void)) {
+        _function.attach(tptr, mptr);
+    }
+ 
+    /** Detach the function
+     */
+    void detach() {
+        remove();
+    }
+    
+    void setNext(int delay) {
+        insert(event.timestamp + delay);
+    }
+    
+    void prime(void) {
+        event.timestamp = us_ticker_read();
+    }
+ 
+protected:
+    virtual void handler() {
+        _function.call();
+    }
+ 
+    unsigned int _delay;
+    FunctionPointer _function;
+};
+
+#endif

--- a/src/modules/JuicyBoard/R1000A_MODBUS/SoftSerial_rx.cpp
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/SoftSerial_rx.cpp
@@ -1,0 +1,95 @@
+/* 
+ * SoftSerial by Erik Olieman
+ * Date: 05 Jul 2014
+ * Revision: 10:236fce2e5b8c
+ * URL: http://developer.mbed.org/users/Sissors/code/SoftSerial/
+ */
+
+#include "libs/Kernel.h"
+#include "SoftSerial.h"
+
+
+uint32_t overhead_us = 200 * 1000000 / SystemCoreClock;         //Random estimation of the overhead of mbed libs, makes slow devices like LPC812 @ 12MHz perform better
+
+int SoftSerial::_getc( void ) {
+    out_valid = false;
+    return out_buffer;
+}
+
+int SoftSerial::readable(void) {
+    return out_valid;
+}
+
+//Start receiving byte
+void SoftSerial::rx_gpio_irq_handler(void) {
+    rxticker.prime();
+    rxticker.setNext(bit_period + (bit_period >> 1) - overhead_us);
+    rx->fall(NULL);
+    rx_bit = 0;
+    rx_error = false;
+};    
+
+void SoftSerial::rx_handler(void) {
+    //Receive data
+    int val = rx->read();
+ 
+    rxticker.setNext(bit_period);
+    rx_bit++;
+    
+    
+    if (rx_bit <= _bits) {
+        read_buffer |= val << (rx_bit - 1);
+        return;
+    }
+    
+    //Receive parity
+    bool parity_count;
+    if (rx_bit == _bits + 1) {
+        switch (_parity) {
+            case Forced1:
+                if (val == 0)
+                    rx_error = true;
+                return;
+            case Forced0:
+                if (val == 1)
+                    rx_error = true;
+                return;
+            case Even:
+            case Odd:
+                parity_count = val;
+                for (int i = 0; i<_bits; i++) {
+                    if (((read_buffer >> i) & 0x01) == 1)
+                        parity_count = !parity_count;
+                }
+                if ((parity_count) && (_parity == Even))
+                    rx_error = true;
+                if ((!parity_count) && (_parity == Odd))
+                    rx_error = true;
+                return;
+            case None:
+                // No parity, nothing to do here
+                break;
+        }
+    }
+    
+    //Receive stop
+    if (rx_bit < _bits + (bool)_parity + _stop_bits) {
+        if (!val)
+            rx_error = true;
+        return;
+    }    
+    
+    //The last stop bit
+    if (!val)
+        rx_error = true;
+    
+    if (!rx_error) {
+        out_valid = true;
+        out_buffer = read_buffer;
+        fpointer[RxIrq].call();
+    }
+    read_buffer = 0;
+    rxticker.detach(); 
+    rx->fall(this, &SoftSerial::rx_gpio_irq_handler);
+}
+

--- a/src/modules/JuicyBoard/R1000A_MODBUS/SoftSerial_tx.cpp
+++ b/src/modules/JuicyBoard/R1000A_MODBUS/SoftSerial_tx.cpp
@@ -1,0 +1,86 @@
+/* 
+ * SoftSerial by Erik Olieman
+ * Date: 05 Jul 2014
+ * Revision: 10:236fce2e5b8c
+ * URL: http://developer.mbed.org/users/Sissors/code/SoftSerial/
+ */
+
+#include "libs/Kernel.h"
+#include "SoftSerial.h"
+
+int SoftSerial::_putc(int c)
+{
+    while(!writeable()){
+        THEKERNEL->call_event(ON_IDLE, this);
+    };
+    prepare_tx(c);
+    tx_bit = 0;
+    txticker.prime();
+    tx_handler();
+    return 0;
+}
+
+int SoftSerial::writeable(void)
+{
+    if (!tx_en)
+        return false;
+    if (tx_bit == -1)
+        return true;
+    return false;
+}
+
+void SoftSerial::tx_handler(void)
+{
+    if (tx_bit == _total_bits) {
+        tx_bit = -1;
+        fpointer[TxIrq].call();
+        return;
+    }
+
+    //Flip output
+    int cur_out = tx->read();
+    tx->write(!cur_out);
+
+    //Calculate when to do it again
+    int count = bit_period;
+    tx_bit++;
+    while(((_char >> tx_bit) & 0x01) == !cur_out) {
+        count+=bit_period;
+        tx_bit++;
+    }
+
+    txticker.setNext(count);
+}
+
+void SoftSerial::prepare_tx(int c)
+{
+    _char = c << 1;
+
+    bool parity;
+    switch (_parity) {
+        case Forced1:
+            _char |= 1 << (_bits + 1);
+        case Forced0:
+            _char &= ~(1 << (_bits + 1));
+        case Even:
+            parity = false;
+            for (int i = 0; i<_bits; i++) {
+                if (((_char >> i) & 0x01) == 1)
+                    parity = !parity;
+            }
+            _char |= parity << (_bits + 1);
+        case Odd:
+            parity = true;
+            for (int i = 0; i<_bits; i++) {
+                if (((_char >> i) & 0x01) == 1)
+                    parity = !parity;
+            }
+            _char |= parity << (_bits + 1);
+        case None:
+            // No parity, nothing to do here
+            break;
+    }
+    
+    _char |= 0xFFFF << (1 + _bits + (bool)_parity);
+    _char &= ~(1<<_total_bits);
+}

--- a/src/modules/tools/temperaturecontrol/TempSensor.h
+++ b/src/modules/tools/temperaturecontrol/TempSensor.h
@@ -22,6 +22,9 @@ public:
     // Return temperature in degrees Celsius.
     virtual float get_temperature() { return -1.0F; }
 
+    virtual void pull_temperature() {}      // Juicyboard PXU specific, forces temperature to be read from PXU, 100ms delay
+    virtual void set_temperature(float) {}  // Juicyboard PXU specific, sets PXU temperature through modbus
+
     typedef std::map<char, float> sensor_options_t;
     virtual bool set_optional(const sensor_options_t& options) { return false; }
     virtual bool get_optional(sensor_options_t& options) { return false; }

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -577,13 +577,7 @@ void TemperatureControl::on_second_tick(void *argument)
         THEKERNEL->streams->printf("%s:%3.1f /%3.1f @%d\n", designator.c_str(), get_temperature(), ((target_temperature <= 0) ? 0.0 : target_temperature), o);
     }
 
-    if (isMODBUS){
-        if ((waiting) | (this->target_temperature <= 0)){
-            sensor->pull_temperature();         // onlly read temperature from PXU when waiting, or else the printer will freeze
-                                                // it takes 100ms to read from PXU device
-        }
-    }
-        
+    sensor->pull_temperature();
 
     // Check whether or not there is a temperature runaway issue, if so stop everything and report it
     if(THEKERNEL->is_halted()) return;

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -54,7 +54,7 @@ class TemperatureControl : public Module {
         TempSensor *sensor;
         
         // Juicyboard PXU (Redlion) specific variable
-        bool isPXU;
+        bool isMODBUS;
 
         float i_max;
         int o;
@@ -63,7 +63,6 @@ class TemperatureControl : public Module {
         Pwm  heater_pin;
 
         std::string designator;
-
 
         float hysteresis;
         float iTerm;

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -52,6 +52,10 @@ class TemperatureControl : public Module {
         float preset2;
 
         TempSensor *sensor;
+        
+        // Juicyboard PXU (Redlion) specific variable
+        bool isPXU;
+
         float i_max;
         int o;
         float last_reading;


### PR DESCRIPTION
Added support for modbus PXU temperature controllers. Smoothie now uses soft serial to control modbus devices, requires a 3.3V UART to RS485 converter.